### PR TITLE
Fix: Correct path to bootstrap.min.js to resolve 404 error

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -791,7 +791,7 @@
     © 2025 Josephat Mwagongo • Built with Bootstrap
 </footer>
 
-<script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/jquery.magnific-popup.min.js"></script>
 


### PR DESCRIPTION
The `index.html` file was referencing a non-existent JavaScript file, `bootstrap.bundle.min.js`, which was causing a 404 Not Found error and preventing the page from loading correctly.

This commit fixes the issue by updating the `<script>` tag to point to the correct file, `bootstrap.min.js`, which is present in the `static/js/` directory.