### PR TITLE
Rename first certificate to Intermediate python for Data Analysis

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1149,11 +1149,11 @@
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center gap-3 text-orange-500">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
-                                    <h4 class="text-lg font-bold font-sans-heading">Basic Python Certificate</h4>
+                                    <h4 class="text-lg font-bold font-sans-heading">Intermediate python for Data Analysis</h4>
                                 </div>
                                 <span class="px-3 py-1 text-xs font-mono bg-slate-800 border border-slate-700 rounded text-slate-400">PDF</span>
                             </div>
-                            <p class="text-slate-400 text-sm">Certification for completing the Basic Python programming course, covering fundamental concepts and syntax.</p>
+                            <p class="text-slate-400 text-sm">Certification for completing the Intermediate Python for Data Analysis course, focusing on data manipulation, visualization, and analysis.</p>
                             <div class="pt-4">
                                 <a href="{{ url_for('static', filename='basic-python-certificate.pdf') }}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 bg-orange-500/10 text-orange-500 border border-orange-500/30 rounded hover:bg-orange-500 hover:text-white transition-colors text-sm font-bold">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>


### PR DESCRIPTION
Renamed the first certificate in the portfolio from 'Basic Python Certificate' to 'Intermediate python for Data Analysis' and updated its description in the HTML template. Verified the change visually with a screenshot.

---
*PR created automatically by Jules for task [8797386559497011063](https://jules.google.com/task/8797386559497011063) started by @ja154*